### PR TITLE
COMN-212: Adjust/add exceptions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,15 @@
 # Cumulative Release Notes for rosette-common-java
 
+## 35.5.0
+
+### COMN-212: Add/adjust common exceptions
+
+Added RosetteUnsupportedLanguageException constructors that take a
+``LanguageCode``.  Deprecated the others.  Added a new exception,
+``RosetteIllegalArgumentException`` to be thrown when a known when an
+invalid argument is passed specifically to a Rosette API.
+
+
 ## 35.4.0
 
 ### COMN-191: Add ZSM language code.

--- a/src/main/java/com/basistech/rosette/RosetteIllegalArgumentException.java
+++ b/src/main/java/com/basistech/rosette/RosetteIllegalArgumentException.java
@@ -1,0 +1,69 @@
+/*
+* Copyright 2014 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette;
+
+/**
+ * Thrown to indicate that a Rosette component has been passed an illegal or
+ * inappropriate argument, for example, if a component requires tokens but
+ * no tokens were supplied.  Receiving a
+ * {@code RosetteIllegalArgumentException} likely means there is a bug in how
+ * the Rosette component is being called, whereas receiving
+ * {@code IllegalArgumentException} might indicate a bug inside the Rosette
+ * component itself.
+ *
+ * @since 35.5.0
+ */
+public class RosetteIllegalArgumentException extends IllegalArgumentException {
+    /**
+     * Constructs a {@code RosetteIllegalArgumentException} with no
+     * detail message.
+     */
+    public RosetteIllegalArgumentException() {
+        super();
+    }
+
+    /**
+     * Constructs a {@code RosetteIllegalArgumentException} with the
+     * specified detail message.
+     *
+     * @param message message
+     */
+    public RosetteIllegalArgumentException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a {@code RosetteIllegalArgumentException} with the specified
+     * detail message and cause.
+     *
+     * @param  message message
+     * @param  cause cause
+     */
+    public RosetteIllegalArgumentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a {@code RosetteIllegalArgumentException} with the specified
+     * cause and a default detail message based on the cause.
+     *
+     * @param cause cause
+     */
+    public RosetteIllegalArgumentException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/basistech/rosette/RosetteUnsupportedLanguageException.java
+++ b/src/main/java/com/basistech/rosette/RosetteUnsupportedLanguageException.java
@@ -13,28 +13,111 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
 package com.basistech.rosette;
 
+import com.basistech.util.LanguageCode;
+
 /**
- * Exception resulting from attempt to use an unsupported language.
+ * Exception resulting from attempting to use an unsupported language.
  */
 public class RosetteUnsupportedLanguageException extends RosetteRuntimeException {
  
     private static final long serialVersionUID = 1L;
+    private final LanguageCode language;
 
+    /**
+     * @deprecated As of version 35.5.0.  Use constructors with {@link com.basistech.util.LanguageCode}
+     */
     public RosetteUnsupportedLanguageException() {
         super();
+        this.language = null;
     }
 
+    /**
+     * @deprecated As of version 35.5.0.  Use constructors with {@link com.basistech.util.LanguageCode}
+     */
+    @Deprecated
     public RosetteUnsupportedLanguageException(String message, Throwable cause) {
         super(message, cause);
+        this.language = null;
     }
 
+    /**
+     * @deprecated As of version 35.5.0.  Use constructors with {@link com.basistech.util.LanguageCode}
+     */
+    @Deprecated
     public RosetteUnsupportedLanguageException(String message) {
         super(message);
+        this.language = null;
     }
 
+    /**
+     * @deprecated As of version 35.5.0.  Use constructors with {@link com.basistech.util.LanguageCode}
+     */
+    @Deprecated
     public RosetteUnsupportedLanguageException(Throwable cause) {
         super(cause);
+        this.language = null;
+    }
+
+    /**
+     * Constructs an {@code RosetteUnsupportedLanguageException} with the
+     * specified language.
+     *
+     * @param language language
+     * @since 35.5.0
+     */
+    public RosetteUnsupportedLanguageException(LanguageCode language) {
+        this(language, null, null);
+    }
+
+    /**
+     * Constructs an {@code RosetteUnsupportedLanguageException} with the
+     * specified language and detail message.
+     *
+     * @param language language
+     * @param message message
+     * @since 35.5.0
+     */
+    public RosetteUnsupportedLanguageException(LanguageCode language, String message) {
+        this(language, message, null);
+    }
+
+    /**
+     * Constructs an {@code RosetteUnsupportedLanguageException} with the
+     * specified language and cause.
+     *
+     * @param language language
+     * @param cause case
+     * @since 35.5.0
+     */
+    public RosetteUnsupportedLanguageException(LanguageCode language, Throwable cause) {
+        this(language, null, cause);
+    }
+
+    /**
+     * Constructs an {@code RosetteUnsupportedLanguageException} with the
+     * specified language, detail message, and cause.
+     *
+     * @param language language
+     * @param message message
+     * @param cause cause
+     * @since 35.5.0
+     */
+    public RosetteUnsupportedLanguageException(LanguageCode language, String message, Throwable cause) {
+        super(String.format("%s (%s)%s", language, language.ISO639_3(),
+            message == null ? "" : ": " + message), cause);
+        this.language = language;
+    }
+
+    /**
+     * Returns the language associated with this exception.
+     *
+     * @return language associated with this exception
+     * @since 35.5.0
+     */
+    public LanguageCode getLanguage() {
+        return language;
     }
 }

--- a/src/test/java/com/basistech/rosette/RLPExceptionsTest.java
+++ b/src/test/java/com/basistech/rosette/RLPExceptionsTest.java
@@ -15,25 +15,18 @@
 */
 package com.basistech.rosette;
 
+import com.basistech.util.LanguageCode;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * Exercises the code in the various Exceptions in the com.basistech.rlp
  * package.
- * 
- * Classes covered:
- *    RosetteException
- *    RosetteRuntimeException
- *    RosetteNoLicenseException
- *    RosetteCorruptLicenseException
- *    RosetteExpiredLicenseException
- *    RosetteUnsupportedLanguageException
  */
-public class RLPExceptionsTest extends Assert {
+public class RLPExceptionsTest {
 
     @Test
-    public void testRosetteException() throws Exception {
+    public void testRosetteException() {
         String message = "generic exception";
         
         // Use constructors
@@ -47,7 +40,7 @@ public class RLPExceptionsTest extends Assert {
     }
     
     @Test
-    public void testRosetteRuntimeException() throws Exception {
+    public void testRosetteRuntimeException() {
         String message = "runtime exception";
         
         // Use constructors
@@ -61,7 +54,7 @@ public class RLPExceptionsTest extends Assert {
     }
 
     @Test
-    public void testRosetteNoLicenseException() throws Exception {
+    public void testRosetteNoLicenseException() {
         String message = "no license found";
         
         // Use constructors
@@ -75,7 +68,7 @@ public class RLPExceptionsTest extends Assert {
     }
 
     @Test
-    public void testRosetteCorruptLicenseException() throws Exception {
+    public void testRosetteCorruptLicenseException() {
         String message = "license has been corrupted";
         
         // Use constructors
@@ -89,7 +82,7 @@ public class RLPExceptionsTest extends Assert {
     }
 
     @Test
-    public void testRosetteExpiredLicenseException() throws Exception {
+    public void testRosetteExpiredLicenseException() {
         String message = "license expired";
         
         // Use constructors
@@ -103,7 +96,7 @@ public class RLPExceptionsTest extends Assert {
     }
 
     @Test
-    public void testRosetteUnsupportedLanguageException() throws Exception {
+    public void testRosetteUnsupportedLanguageExceptionDeprecated() {
         String message = "language not supported";
         
         // Use constructors
@@ -114,5 +107,43 @@ public class RLPExceptionsTest extends Assert {
         
         // test the message
         Assert.assertEquals(message, e.getMessage());
+    }
+
+    @Test
+    public void testRosetteUnsupportedLanguageException() {
+        RosetteUnsupportedLanguageException e;
+        e = new RosetteUnsupportedLanguageException(LanguageCode.AFRIKAANS);
+        Assert.assertEquals(LanguageCode.AFRIKAANS, e.getLanguage());
+        Assert.assertEquals("AFRIKAANS (afr)", e.getMessage());
+        Assert.assertNull(e.getCause());
+        e = new RosetteUnsupportedLanguageException(LanguageCode.AFRIKAANS, "foo");
+        Assert.assertEquals(LanguageCode.AFRIKAANS, e.getLanguage());
+        Assert.assertEquals("AFRIKAANS (afr): foo", e.getMessage());
+        Assert.assertNull(e.getCause());
+        e = new RosetteUnsupportedLanguageException(LanguageCode.AFRIKAANS, new RuntimeException());
+        Assert.assertEquals(LanguageCode.AFRIKAANS, e.getLanguage());
+        Assert.assertEquals("AFRIKAANS (afr)", e.getMessage());
+        Assert.assertNotNull(e.getCause());
+        e = new RosetteUnsupportedLanguageException(LanguageCode.AFRIKAANS, "foo", new RuntimeException());
+        Assert.assertEquals(LanguageCode.AFRIKAANS, e.getLanguage());
+        Assert.assertEquals("AFRIKAANS (afr): foo", e.getMessage());
+        Assert.assertNotNull(e.getCause());
+    }
+
+    @Test
+    public void testRosetteIllegalArgumentException() {
+        RosetteIllegalArgumentException e;
+        e = new RosetteIllegalArgumentException();
+        Assert.assertNull(e.getMessage());
+        Assert.assertNull(e.getCause());
+        e = new RosetteIllegalArgumentException("foo");
+        Assert.assertEquals("foo", e.getMessage());
+        Assert.assertNull(e.getCause());
+        e = new RosetteIllegalArgumentException(new RuntimeException());
+        Assert.assertNotNull(e.getMessage());  // "java.lang.RuntimeException"
+        Assert.assertNotNull(e.getCause());
+        e = new RosetteIllegalArgumentException("foo", new RuntimeException());
+        Assert.assertEquals("foo", e.getMessage());
+        Assert.assertNotNull(e.getCause());
     }
 }


### PR DESCRIPTION
RosetteUnsupportedLanguageException now requires a language code.
New exception RosetteIllegalArgumentException.