### PR TITLE
ROS-240: fill in missing call to super.setupModule.

### DIFF
--- a/api-jackson/src/main/java/com/basistech/util/jackson/EnumModule.java
+++ b/api-jackson/src/main/java/com/basistech/util/jackson/EnumModule.java
@@ -37,6 +37,7 @@ public class EnumModule extends SimpleModule {
     }
 
     public void setupModule(SetupContext context) {
+        super.setupModule(context);
         context.setMixInAnnotations(LanguageCode.class, LanguageCodeMixin.class);
         SimpleSerializers keySerializers = new SimpleSerializers();
         keySerializers.addSerializer(new LanguageCodeKeySerializer());


### PR DESCRIPTION
I left out the call to 'super' in EnumModule.setupModule, which makes it impossible to use certain features 'upstairs' in the ADM module.